### PR TITLE
Fix sha1_suffix bug

### DIFF
--- a/wp/utils.py
+++ b/wp/utils.py
@@ -359,7 +359,7 @@ class FastAudit():
     def pwnedPass(self):
         """checks if password(sha1) has been used before"""
         sha1_prefix = self.__pass[:5]
-        sha1_suffix = self.__pass[5:0]
+        sha1_suffix = self.__pass[5:]
         print '\n{}[*]{} Checking if password has been used/breeched before...'.format(B, S)
         url = 'https://api.pwnedpasswords.com/range/{}'.format(sha1_prefix)
         if self.__save:


### PR DESCRIPTION
This PR fixes a bug with determining the ```sha1_suffix```.

This should take care of the bug mentioned here: https://github.com/chrispetrou/FastAudit/pull/1.

That is, if ```self.__pass``` is purely a SHA1 hash. If ```self.__pass``` looks exactly like this format, then another step needs to be added: ```7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53:passw0rd```. If ```self.__pass``` looks like this, then this PR should fix the issue: ```7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53```.